### PR TITLE
Change LONGURL to icingadb as ido / monitoring module is deprecated

### DIFF
--- a/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
@@ -106,7 +106,7 @@ EOF
 
 ## Check whether Icinga Web 2 URL was specified.
 if [ -n "$ICINGAWEB2URL" ] ; then
-  LONGURL="${ICINGAWEB2URL}/monitoring/host/show?host=$(urlencode "${HOSTNAME}")"
+  LONGURL="${ICINGAWEB2URL}/icingadb/host?name=$(urlencode "${HOSTNAME}")"
   SHORTURL=$({{ icinga2_master_twilio_shorturl_cmd }})
 
   if [ ! -z ${SHORTURL} ]; then

--- a/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
@@ -113,7 +113,7 @@ EOF
 
 ## Check whether Icinga Web 2 URL was specified.
 if [ -n "$ICINGAWEB2URL" ] ; then
-  LONGURL="${ICINGAWEB2URL}/monitoring/service/show?host=$(urlencode "${HOSTNAME}&")service=$(urlencode "${SERVICENAME}")"
+  LONGURL="${ICINGAWEB2URL}/icingadb/host?name=$(urlencode "${HOSTNAME}")"
   SHORTURL=$({{ icinga2_master_twilio_shorturl_cmd }})
 
   if [ ! -z ${SHORTURL} ]; then


### PR DESCRIPTION
##### SUMMARY
Changed $LONGURL to send links working with icingadb as ido is deprecated.
