### PR TITLE
change url for services in sms

### DIFF
--- a/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
@@ -113,7 +113,7 @@ EOF
 
 ## Check whether Icinga Web 2 URL was specified.
 if [ -n "$ICINGAWEB2URL" ] ; then
-  LONGURL="${ICINGAWEB2URL}/icingadb/host?name=$(urlencode "${HOSTNAME}")"
+  LONGURL="${ICINGAWEB2URL}/icingadb/service?name=$(urlencode "$SERVICENAME")&host.name=$(urlencode "$HOSTNAME")"
   SHORTURL=$({{ icinga2_master_twilio_shorturl_cmd }})
 
   if [ ! -z ${SHORTURL} ]; then


### PR DESCRIPTION
##### SUMMARY
change the url used for services as they now do not reflect the actuall url used for service but instead just link to the host
