### PR TITLE
Add option to pass additional/custom information to notification scripts

### DIFF
--- a/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
@@ -11,7 +11,7 @@ account_sid="{{ icinga2_master_twilio_account_sid }}"
 auth_token="{{ icinga2_master_twilio_auth_token }}"
 phone_number="{{ icinga2_master_twilio_sms_from }}"
 
-PROG="$(basename "$0")"
+PROG=${0##*/}
 
 ## Function helpers
 Usage() {

--- a/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
@@ -30,6 +30,7 @@ Optional parameters:
   -b NOTIFICATIONAUTHORNAME (\$notification.author\$)
   -i ICINGAWEB2URL (\$notification_icingaweb2url\$, Default: unset)
   -v (\$notification_sendtosyslog\$, Default: false)
+  -X (\$notification_extradata\$, Default: unset)
 
 EOF
 }
@@ -60,7 +61,8 @@ urlencode() {
 {% endraw %}
 
 ## Main
-while getopts d:hi:l:n:o:r:s:t:v: opt
+EXTRA_DATA=
+while getopts d:hi:l:n:o:r:s:t:v:X: opt
 do
   case "$opt" in
     d) LONGDATETIME=$OPTARG ;; # required
@@ -73,6 +75,7 @@ do
     s) HOSTSTATE=$OPTARG ;; # required
     t) NOTIFICATIONTYPE=$OPTARG ;; # required
     v) VERBOSE=$OPTARG ;;
+    X) EXTRA_DATA=$OPTARG ;;
    \?) echo "ERROR: Invalid option -$OPTARG" >&2
        Error ;;
     :) echo "Missing option argument for -$OPTARG" >&2

--- a/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
@@ -29,7 +29,6 @@ Required parameters:
 Optional parameters:
   -b NOTIFICATIONAUTHORNAME (\$notification.author\$)
   -i ICINGAWEB2URL (\$notification_icingaweb2url\$, Default: unset)
-  -r USERPHONE (\$user.pager\$)
   -v (\$notification_sendtosyslog\$, Default: false)
 
 EOF

--- a/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
@@ -30,7 +30,6 @@ Required parameters:
 
 Optional parameters:
   -i ICINGAWEB2URL (\$notification_icingaweb2url\$, Default: unset)
-  -r USERPHONE (\$user.pager\$)
   -v (\$notification_sendtosyslog\$, Default: false)
 
 EOF

--- a/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
@@ -11,7 +11,7 @@ account_sid="{{ icinga2_master_twilio_account_sid }}"
 auth_token="{{ icinga2_master_twilio_auth_token }}"
 phone_number="{{ icinga2_master_twilio_sms_from }}"
 
-PROG="$(basename "$0")"
+PROG=${0##*/}
 
 ## Function helpers
 Usage() {

--- a/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-service-notification.sh.j2
@@ -31,6 +31,7 @@ Required parameters:
 Optional parameters:
   -i ICINGAWEB2URL (\$notification_icingaweb2url\$, Default: unset)
   -v (\$notification_sendtosyslog\$, Default: false)
+  -X EXTRA_DATA (\$notification_extradata\$, Default: unset)
 
 EOF
 }
@@ -61,7 +62,8 @@ urlencode() {
 {% endraw %}
 
 ## Main
-while getopts d:e:hi:l:n:o:r:s:t:u:v: opt
+EXTRA_DATA=
+while getopts d:e:hi:l:n:o:r:s:t:u:v:X: opt
 do
   case "$opt" in
     d) LONGDATETIME=$OPTARG ;; # required
@@ -76,6 +78,7 @@ do
     t) NOTIFICATIONTYPE=$OPTARG ;; # required
     u) SERVICEDISPLAYNAME=$OPTARG ;; # required
     v) VERBOSE=$OPTARG ;;
+    X) EXTRA_DATA=$OPTARG ;;
    \?) echo "ERROR: Invalid option -$OPTARG" >&2
        Usage ;;
     :) echo "Missing option argument for -$OPTARG" >&2


### PR DESCRIPTION
##### SUMMARY

In our environment, notification SMSes are sent to different users depending on the team to which a service is assigned *and* the team in which a user is.

We also send a copy of the SMS to other communication channels (e.g. Mattermost) for easier tracking/interaction, but in that case, all notifications (regardless of the assigned team) end up in the same place.

It would be nice to have a way to filter notifications by teams (or based on any other custom information). These changes implement a way to do so.

##### ISSUE TYPE

 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible [core 2.12.10]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/martinwe/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /home/martinwe/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.9.2 (default, Feb 28 2021, 17:03:44) [GCC 10.2.1 20210110]
  jinja version = 2.11.3
  libyaml = True
```

##### ADDITIONAL INFORMATION

There is now an additional commandline option (`-X`), which is optional. It takes any string as argument.

The script continues to work if the command template, command, notification template and notifications in Icinga2 have not been set up to use the option. In fact, the script by itself does not do anything with the additional option&mdash;it is merely a way to communicate additional information to the playbook author (for use in `icinga2_master_twilio_sms_additional_commands`).

To make use of the option, it is recommended to check if the option has been passed with a non-empty value; most easily something like:

```yaml
icinga2_master_twilio_sms_additional_commands:
  - …
  - 'if [ -n "$EXTRA_DATA" ]; then …; fi'
  - …
```