### PR TITLE
ci: Fix branch of ansible-lint

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -24,7 +24,7 @@ jobs:
           path: lint-rules
 
       - name: ansible-lint
-        uses: ansible/ansible-lint-action@master
+        uses: ansible/ansible-lint-action@main
         with:
           targets: icinga2_master
           args: "-R -r lint-rules"


### PR DESCRIPTION
##### SUMMARY
Ansible changed the default branch of their action, thus CI pipelines fail

##### ISSUE TYPE
 - Bugfix Pull Request


