### PR TITLE
twilio-sms-host-notification: Add missing -X argument in help output

### DIFF
--- a/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
+++ b/templates/etc/icinga2/scripts/twilio-sms-host-notification.sh.j2
@@ -30,7 +30,7 @@ Optional parameters:
   -b NOTIFICATIONAUTHORNAME (\$notification.author\$)
   -i ICINGAWEB2URL (\$notification_icingaweb2url\$, Default: unset)
   -v (\$notification_sendtosyslog\$, Default: false)
-  -X (\$notification_extradata\$, Default: unset)
+  -X EXTRA_DATA (\$notification_extradata\$, Default: unset)
 
 EOF
 }


### PR DESCRIPTION
##### SUMMARY

`-X` expects an argument, the help output should correctly reflect this (compare with `twilio-sms-service-notification`).

##### ISSUE TYPE

 - Docs Pull Request

##### ANSIBLE VERSION

```
/usr/lib/python3/dist-packages/paramiko/transport.py:219: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
ansible [core 2.12.10]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/martinwe/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /home/martinwe/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.9.2 (default, Feb 28 2021, 17:03:44) [GCC 10.2.1 20210110]
  jinja version = 3.1.2
  libyaml = True
```

##### ADDITIONAL INFORMATION

Fixes an oversight in the previous PR (#119).