### PR TITLE
ci: publish to galaxy on release only

### DIFF
--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -1,7 +1,7 @@
 ---
 name: CI - Linting
 
-'on':
+on:
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -2,9 +2,8 @@
 name: Publish on Ansible Galaxy
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [created, edited, published, released]
 
 jobs:
   build:


### PR DESCRIPTION
##### SUMMARY
This PR improves the CI to make sure only releases are published to ansible galaxy. 

##### ISSUE TYPE
 - Bugfix Pull Request

