### PR TITLE
fix: move roles var to dedicated file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 
+# Increment this whenever you make breaking changes to the role
+icinga2_master_role_revision: "1"
+
 # The icinga2 master zone
 icinga2_master_master_zone: monitoring-master
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,5 @@
 ---
 
-# Increment this whenever you make breaking changes to the role
-icinga2_master_role_revision: "1"
-
 # The icinga2 master zone
 icinga2_master_master_zone: monitoring-master
 

--- a/meta/version.yaml
+++ b/meta/version.yaml
@@ -1,0 +1,4 @@
+# Increment this whenever you make breaking changes to the role
+icinga2_master_role_revision: "1"
+
+# This file can be included in playbooks using include_vars before the role runs.


### PR DESCRIPTION
This allows querying the role version from a playbook prematurely using `include_vars`.